### PR TITLE
[fix] 退会済みユーザーも再招待できるように修正

### DIFF
--- a/src/laravel-chat/app/Http/Controllers/InvitationController.php
+++ b/src/laravel-chat/app/Http/Controllers/InvitationController.php
@@ -23,7 +23,7 @@ class InvitationController extends Controller
         if (!$group->isAdmin(Auth::user())) {
             return redirect()->back()->with('error', '管理者権限が必要です');
         }
-        if ($group->users()->where('users.id', $user->id)->exists()) {
+        if ($group->isActiveMember($user)) {
             return back()->with('info', "{$user->name}さんは既にこのグループのメンバーです。");
         }
         try {
@@ -31,6 +31,7 @@ class InvitationController extends Controller
                 $existing = Invitation::where('group_id', $group->id)
                     ->where('invitee_email', $user->email)
                     ->where('expires_at', '>', now())
+                    ->whereNull('accepted_at')
                     ->lockForUpdate() // 占有ロック
                     ->first();
                 if ($existing) {


### PR DESCRIPTION
グループの在籍判定ロジックを修正（退会済みユーザーを除外するように）
招待の重複判定を改善（既に参加済み・使用済みの招待は「招待済み」と判定しないように）
close #34