### PR TITLE
[feat] 管理者限定のエンドポイントに認可チェックを追加

### DIFF
--- a/src/laravel-chat/app/Http/Controllers/GroupController.php
+++ b/src/laravel-chat/app/Http/Controllers/GroupController.php
@@ -61,6 +61,10 @@ class GroupController extends Controller
     public function update(UpdateGroupRequest $request, Group $group) {
         $request->validated();
 
+        if (!$group->isAdmin(Auth::user())) {
+            return redirect()->back()->with('error', '管理者権限が必要です');
+        }
+
         $group->fill($request->only(['name', 'description']));
 
         $group->save();

--- a/src/laravel-chat/app/Http/Controllers/MemberController.php
+++ b/src/laravel-chat/app/Http/Controllers/MemberController.php
@@ -81,6 +81,9 @@ class MemberController extends Controller
         if (!$group->isActiveMember($user)) {
             return redirect()->back()->with('error', 'このユーザーは既に退会済みです');
         }
+        if (!$group->isAdmin(Auth::user())) {
+            return redirect()->back()->with('error', '管理者権限が必要です');
+        }
         $group->users()->updateExistingPivot($user->id, [
             'left_at' => now(),
         ]);


### PR DESCRIPTION
以下の操作のエンドポイントに認可チェックを追加
・グループ名、説明文の変更
・メンバーの強制退会
#60 