### PR TITLE
[refactor] 管理者権限チェックを ->authorize('admin', ) に統一

### DIFF
--- a/src/laravel-chat/app/Http/Controllers/GroupController.php
+++ b/src/laravel-chat/app/Http/Controllers/GroupController.php
@@ -61,9 +61,7 @@ class GroupController extends Controller
     public function update(UpdateGroupRequest $request, Group $group) {
         $request->validated();
 
-        if (!$group->isAdmin(Auth::user())) {
-            abort(403, '管理者権限が必要です');
-        }
+        $this->authorize('admin', $group);
 
         $group->fill($request->only(['name', 'description']));
 

--- a/src/laravel-chat/app/Http/Controllers/InvitationController.php
+++ b/src/laravel-chat/app/Http/Controllers/InvitationController.php
@@ -8,21 +8,23 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 use App\Models\Group;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use App\Models\User;
 use App\Models\Invitation;
 use App\Mail\GroupInvitation;
 
 class InvitationController extends Controller
 {
+    use AuthorizesRequests;
+
     public function invite(Request $request, Group $group) {
         $request->validate([
             'user_id' => 'required|exists:users,id',
         ]);
 
         $user = User::find($request->user_id);
-        if (!$group->isAdmin(Auth::user())) {
-            return redirect()->back()->with('error', '管理者権限が必要です');
-        }
+
+        $this->authorize('admin', $group);
         if ($group->isActiveMember($user)) {
             return back()->with('info', "{$user->name}さんは既にこのグループのメンバーです。");
         }
@@ -63,9 +65,7 @@ class InvitationController extends Controller
     }
 
     public function resend(Group $group, Invitation $invitation) {
-        if (!$group->isAdmin(Auth::user())) {
-            abort(403, '管理者権限が必要です');
-        }
+        $this->authorize('admin', $group);
         if ($invitation->group_id !== $group->id) {
             return back()->with('error', 'この招待はこのグループに属していません');
         }

--- a/src/laravel-chat/app/Http/Controllers/MemberController.php
+++ b/src/laravel-chat/app/Http/Controllers/MemberController.php
@@ -4,12 +4,15 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use App\Models\User;
 use App\Models\Group;
 use Illuminate\Support\Facades\DB;
 
 class MemberController extends Controller
 {
+    use AuthorizesRequests;
+
     public function join($groupId, $token) {
         $group = Group::findOrFail($groupId);
         $user = Auth::user();
@@ -81,9 +84,7 @@ class MemberController extends Controller
         if (!$group->isActiveMember($user)) {
             return redirect()->back()->with('error', 'このユーザーは既に退会済みです');
         }
-        if (!$group->isAdmin(Auth::user())) {
-            return redirect()->back()->with('error', '管理者権限が必要です');
-        }
+        $this->authorize('admin', $group);
         $group->users()->updateExistingPivot($user->id, [
             'left_at' => now(),
         ]);

--- a/src/laravel-chat/tests/Feature/AdminTest.php
+++ b/src/laravel-chat/tests/Feature/AdminTest.php
@@ -219,7 +219,7 @@ class AdminTest extends TestCase
             ['user_id' => $inviteUser->id,]
         );
 
-        $response->assertStatus(302);
+        $response->assertForbidden();
 
         $this->assertDatabaseMissing('invitations', [
             'group_id'       => $this->group->id,
@@ -238,7 +238,7 @@ class AdminTest extends TestCase
             ['user_id' => $inviteUser->id,]
         );
 
-        $response->assertStatus(302);
+        $response->assertForbidden();
 
         $this->assertDatabaseMissing('invitations', [
             'group_id'       => $this->group->id,
@@ -257,7 +257,7 @@ class AdminTest extends TestCase
             ['user_id' => $inviteUser->id,]
         );
 
-        $response->assertStatus(302);
+        $response->assertForbidden();
 
         $this->assertDatabaseMissing('invitations', [
             'group_id'       => $this->group->id,
@@ -312,7 +312,7 @@ class AdminTest extends TestCase
             ])
         );
 
-        $response->assertStatus(302);
+        $response->assertForbidden();
 
         $this->assertDatabaseMissing('group_user', [
             'group_id' => $this->group->id,
@@ -340,7 +340,7 @@ class AdminTest extends TestCase
             ])
         );
 
-        $response->assertStatus(302);
+        $response->assertForbidden();
 
         $this->assertDatabaseMissing('group_user', [
             'group_id' => $this->group->id,
@@ -368,7 +368,7 @@ class AdminTest extends TestCase
             ])
         );
 
-        $response->assertStatus(302);
+        $response->assertForbidden();
 
         $this->assertDatabaseMissing('group_user', [
             'group_id' => $this->group->id,


### PR DESCRIPTION
・以下メソッドの管理者チェックをポリシーに統一
　-edit
　-update
　-remove
　-invite
　-resend
・それに伴い、invite及びremoveの失敗テストを403に変更
close #67 