### PR TITLE
[fix] コンクリフト解消

### DIFF
--- a/src/laravel-chat/app/Http/Controllers/GroupController.php
+++ b/src/laravel-chat/app/Http/Controllers/GroupController.php
@@ -18,12 +18,14 @@ class GroupController extends Controller
 
     public function index(Request $request) {
         $user = Auth::user();
-<<<<<<< HEAD
-        $groups = Group::whereNull('archived_at')->withExists(['users as is_joined' => function ($query) use ($user) {
-=======
         $filter = $request->query('filter');
 
-        $query = Group::query();
+        $query = Group::query()->whereNull('archived_at')
+            ->withExists(['users as is_joined' => function ($q) use ($user) {
+                $q->where('users.id', $user->id)
+                    ->whereNull('left_at')
+                    ->whereNotNull('joined_at');
+            }]);
 
         if ($filter === 'joined') {
             $query->whereHas('users', function ($q) use ($user) {
@@ -41,15 +43,10 @@ class GroupController extends Controller
             });
         }
 
-        $groups = $query->withExists(['users as is_joined' => function ($query) use ($user) {
->>>>>>> master
-            $query->where('users.id', $user->id)
-            ->whereNull('left_at')
-            ->whereNotNull('joined_at');
-        }])->get();
+        $groups = $query->get();
+
         return view('group', compact('groups', 'filter'));
     }
-
     public function add(Request $request) {
         $request->validate([
             'name' => 'required|string|max:10',

--- a/src/laravel-chat/resources/css/app.css
+++ b/src/laravel-chat/resources/css/app.css
@@ -101,13 +101,8 @@ td {
     visibility: visible;
     animation: fadein 0.5s, fadeout 0.5s 2.5s;
 }
-<<<<<<< HEAD
-.btn-warning {
-    margin: 40px auto;
-=======
 a.active {
     font-weight: bold;
     pointer-events: none;
     cursor: default;
->>>>>>> master
 }

--- a/src/laravel-chat/resources/css/app.css
+++ b/src/laravel-chat/resources/css/app.css
@@ -106,3 +106,6 @@ a.active {
     pointer-events: none;
     cursor: default;
 }
+.btn-warning {
+    margin: 40px auto;
+}


### PR DESCRIPTION
同じ変数 $groups に対して、以下の2つの異なる構築ロジックが衝突していたのを修正
-アーカイブチャットの除外
-フィルタリング