### PR TITLE
[feat] 管理者ロールの解除

### DIFF
--- a/src/laravel-chat/app/Http/Controllers/MemberController.php
+++ b/src/laravel-chat/app/Http/Controllers/MemberController.php
@@ -98,4 +98,41 @@ class MemberController extends Controller
         ]);
         return redirect()->back()->with('success', '管理権を与えました');
     }
+
+    public function demote(Group $group) {
+        $this->authorize('admin', $group);
+        $user = Auth::user();
+
+        try {
+            $result = DB::transaction(function () use ($group, $user) {
+                if ($group->isAdmin($user)) {
+                    $adminCount = $group->users()
+                        ->wherePivot('left_at', null)
+                        ->wherePivot('role', 'admin')
+                        ->wherePivotNotNull('joined_at') // 参加済みの確認
+                        ->lockForUpdate() // 占有ロック
+                        ->count();
+                    if ($adminCount <= 1) {
+                        return ['success' => false, 'reason' => 'last_admin'];
+                    }
+                }
+                // 降格処理
+                $group->users()->updateExistingPivot($user->id, [
+                    'role' => 'member',
+                ]);
+                return ['success' => true];
+            });
+            // トランザクション完了後に結果のHTTPレスポンスを返す
+            if ($result['success']) {
+                return redirect()->route('groups.index')->with('success', '管理者から降格しました');
+            } else {
+                if ($result['reason'] === 'last_admin') {
+                    return redirect()->back()->with('error', '管理者が1人しかいないため、降格できません。');
+                }
+                return redirect()->back()->with('error', '降格処理に失敗しました');
+            }
+        } catch (\Exception $e) {
+            return redirect()->back()->with('error', '降格処理中にエラーが発生しました');
+        }
+    }
 }

--- a/src/laravel-chat/app/Http/Controllers/MemberController.php
+++ b/src/laravel-chat/app/Http/Controllers/MemberController.php
@@ -85,39 +85,17 @@ class MemberController extends Controller
         return redirect()->back()->with('success', '管理権を与えました');
     }
 
-    public function demote(Group $group) {
+    public function demote(Group $group, GroupMemberService $service) {
         $this->authorize('admin', $group);
         $user = Auth::user();
 
         try {
-            $result = DB::transaction(function () use ($group, $user) {
-                if ($group->isAdmin($user)) {
-                    $adminCount = $group->users()
-                        ->wherePivot('left_at', null)
-                        ->wherePivot('role', 'admin')
-                        ->wherePivotNotNull('joined_at') // 参加済みの確認
-                        ->lockForUpdate() // 占有ロック
-                        ->count();
-                    if ($adminCount <= 1) {
-                        return ['success' => false, 'reason' => 'last_admin'];
-                    }
-                }
-                // 降格処理
-                $group->users()->updateExistingPivot($user->id, [
-                    'role' => 'member',
-                ]);
-                return ['success' => true];
-            });
-            // トランザクション完了後に結果のHTTPレスポンスを返す
-            if ($result['success']) {
-                return redirect()->route('groups.index')->with('success', '管理者から降格しました');
-            } else {
-                if ($result['reason'] === 'last_admin') {
-                    return redirect()->back()->with('error', '管理者が1人しかいないため、降格できません。');
-                }
-                return redirect()->back()->with('error', '降格処理に失敗しました');
-            }
-        } catch (\Exception $e) {
+            $service->demote($group, $user);
+
+            return redirect()->route('groups.index')->with('success', '管理者から降格しました');
+        } catch (\App\Exceptions\Domain\LastAdminException $e) {
+            return redirect()->back()->with('error', '管理者が1人しかいないため、降格できません。');
+        } catch (\Throwable $e) {
             return redirect()->back()->with('error', '降格処理中にエラーが発生しました');
         }
     }

--- a/src/laravel-chat/app/Services/GroupMemberService.php
+++ b/src/laravel-chat/app/Services/GroupMemberService.php
@@ -34,4 +34,14 @@ class GroupMemberService
             ]);
         });
     }
+
+    public function demote(Group $group, User $user) {
+        DB::transaction(function () use ($group, $user) {
+            $this->adminService->ensureNotLastAdmin($group, $user);
+
+            $group->users()->updateExistingPivot($user->id, [
+                'role' => 'member',
+            ]);
+        });
+    }
 }

--- a/src/laravel-chat/resources/views/edit.blade.php
+++ b/src/laravel-chat/resources/views/edit.blade.php
@@ -130,6 +130,12 @@
                         @endforeach
                     </tbody>
                 </table>
+                <form action="{{ route('groups.members.demote', $group->id) }}" method="POST">
+                    @csrf
+                    @method('PUT')
+                    <button type="submit" class="btn btn-warning bg-blue-500 px-4 py-2"
+                    onclick="return confirm('本当にこのグループの管理者をやめますか？');">管理者を降格</button>
+                </form>
             </div>
         </ul>
     </div>

--- a/src/laravel-chat/routes/web.php
+++ b/src/laravel-chat/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
                 Route::delete('/me', [MemberController::class, 'leave'])->name('leave');
                 Route::delete('/{user}', [MemberController::class, 'remove'])->name('remove');
                 Route::put('/{user}/transfer', [MemberController::class, 'transfer'])->name('transfer');
+                Route::put('/demote', [MemberController::class, 'demote'])->name('demote');
             });
 
             // 招待管理

--- a/src/laravel-chat/tests/Feature/DemoteTest.php
+++ b/src/laravel-chat/tests/Feature/DemoteTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Group;
+
+class DemoteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ?User $user = null;
+    private ?Group $group = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(); // 1回だけユーザーを作成
+        $this->group = Group::factory()->create(); // 1回だけグループを作成
+        Carbon::setTestNow('2025-04-15 19:00:00');
+    }
+
+    private function adminGroup(User $user, Group $group): void
+    {
+        $group->users()->attach($user->id, [
+            'joined_at' => now(),
+            'left_at' => null,
+            'role' => 'admin',
+        ]);
+    }
+
+    private function joinGroup(User $user, Group $group): void
+    {
+        $group->users()->attach($user->id, [
+            'joined_at' => now(),
+            'left_at' => null,
+        ]);
+    }
+
+    private function leftadminGroup(User $user, Group $group): void
+    {
+        $group->users()->attach($user->id, [
+            'joined_at' => '2025-04-07 08:30:17',
+            'left_at' => now(),
+            'role' => 'admin',
+        ]);
+    }
+
+    public function test_can_demote_not_last_admin(): void
+    {
+        $this->actingAs($this->user);
+        $this->adminGroup($this->user, $this->group);
+
+        $anotheradmin = User::factory()->create();
+        $this->adminGroup($anotheradmin, $this->group);
+
+        $response = $this->put(
+            route('groups.members.demote', [
+                'group' => $this->group->id,
+            ])
+        );
+
+        $this->assertAuthenticated();
+        $response->assertSessionHasNoErrors();
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('group_user', [
+            'group_id' => $this->group->id,
+            'user_id'  => $this->user->id,
+            'role'       => 'member',
+        ]);
+
+        $this->assertFalse(
+            $this->group->isAdmin($this->user),
+        );
+    }
+
+    public function test_cannot_demote_with_last_admin(): void
+    {
+        $this->actingAs($this->user);
+        $this->adminGroup($this->user, $this->group);
+
+        $response = $this->put(
+            route('groups.members.demote', [
+                'group' => $this->group->id,
+            ])
+        );
+
+        $this->assertAuthenticated();
+        $response->assertStatus(302);
+
+        $this->assertDatabaseHas('group_user', [
+            'group_id' => $this->group->id,
+            'user_id'  => $this->user->id,
+            'role'       => 'admin',
+        ]);
+
+        $this->assertTrue(
+            $this->group->isAdmin($this->user),
+        );
+    }
+
+    public function test_cannot_demote_with_not_admin(): void
+    {
+        $this->actingAs($this->user);
+        $this->joinGroup($this->user, $this->group);
+
+        $response = $this->put(
+            route('groups.members.demote', [
+                'group' => $this->group->id,
+            ])
+        );
+
+        $this->assertAuthenticated();
+        $response->assertStatus(403);
+    }
+
+    public function test_cannot_demote_with_other_admin(): void
+    {
+        $otherGroup = Group::factory()->create();
+        $this->adminGroup($this->user, $otherGroup);
+        $this->actingAs($this->user);
+
+        $response = $this->put(
+            route('groups.members.demote', [
+                'group' => $this->group->id,
+            ])
+        );
+
+        $this->assertAuthenticated();
+        $response->assertStatus(403);
+
+        $this->assertDatabaseHas('group_user', [
+            'group_id' => $otherGroup->id,
+            'user_id'  => $this->user->id,
+            'role'       => 'admin',
+        ]);
+
+        $this->assertTrue(
+            $otherGroup->isAdmin($this->user),
+        );
+    }
+
+    public function test_cannot_demote_with_left_admin(): void
+    {
+        $this->actingAs($this->user);
+        $this->leftadminGroup($this->user, $this->group);
+
+        $response = $this->put(
+            route('groups.members.demote', [
+                'group' => $this->group->id,
+            ])
+        );
+
+        $this->assertAuthenticated();
+        $response->assertStatus(403);
+    }
+}

--- a/src/laravel-chat/tests/Feature/Service/GroupMemberService/demoteTest.php
+++ b/src/laravel-chat/tests/Feature/Service/GroupMemberService/demoteTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Service\GroupMemberService;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Group;
+use App\Services\GroupMemberService;
+use App\Exceptions\Domain\LastAdminException;
+
+class DemoteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ?User $user = null;
+    private ?Group $group = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(); // 1回だけユーザーを作成
+        $this->group = Group::factory()->create(); // 1回だけグループを作成
+        Carbon::setTestNow('2025-04-15 19:00:00');
+    }
+
+    private function adminGroup(User $user, Group $group): void
+    {
+        $group->users()->attach($user->id, [
+            'joined_at' => now(),
+            'left_at' => null,
+            'role' => 'admin',
+        ]);
+    }
+
+    public function test_last_admin_cannot_demote(): void
+    {
+        $this->actingAs($this->user);
+        $this->adminGroup($this->user, $this->group);
+
+        $service = app(GroupMemberService::class);
+
+        $this->expectException(LastAdminException::class);
+
+        $service->demote($this->group, $this->user);
+    }
+
+    public function test_admin_can_demote_if_multiple_admins(): void
+    {
+        $this->actingAs($this->user);
+        $this->adminGroup($this->user, $this->group);
+
+        $anotheradmin = User::factory()->create();
+        $this->adminGroup($anotheradmin, $this->group);
+
+        $service = app(GroupMemberService::class);
+
+        $service->demote($this->group, $this->user);
+
+        $this->assertDatabaseHas('group_user', [
+            'user_id' => $this->user->id,
+            'role' => 'member',
+        ]);
+    }
+}


### PR DESCRIPTION
1.同一グループ内に他の管理者が1人以上存在する場合のみ、管理者が自分自身を降格できる
2.API仕様が確定・実装されている
　　エンドポイント
　　PUT /groups/{group}/members/demote
　挙動
　　自分自身を対象とした降格リクエストが可能

close #82 