### PR TITLE
[refactor] Group モデルで管理しているグループ参加状態の判定ロジックを整理

### DIFF
--- a/src/laravel-chat/app/Http/Controllers/GroupController.php
+++ b/src/laravel-chat/app/Http/Controllers/GroupController.php
@@ -26,6 +26,10 @@ class GroupController extends Controller
                 'activeUsersQuery as is_joined' => function ($q) use ($user) {
                     $q->where('users.id', $user->id);
                 },
+
+                'users as is_applying' => function ($q) use ($user) {
+                    $q->where('users.id', $user->id);
+                },
             ]);
         if ($filter === 'joined') {
             $query->whereHas('activeUsersQuery', function ($q) use ($user) {

--- a/src/laravel-chat/app/Http/Controllers/GroupController.php
+++ b/src/laravel-chat/app/Http/Controllers/GroupController.php
@@ -20,27 +20,23 @@ class GroupController extends Controller
         $user = Auth::user();
         $filter = $request->query('filter');
 
-        $activeMember = function ($q) use ($user) {
-            $q->where('users.id', $user->id)
-                ->whereNull('left_at')
-                ->whereNotNull('joined_at');
-        };
-
         $query = Group::query()
             ->whereNull('archived_at')
             ->withExists([
-                'users as is_joined' => $activeMember,
-                'users as is_applying' => function ($q) use ($user) {
-                    $q->where('users.id', $user->id)
-                    ->where('role', 'applicant');
+                'activeUsersQuery as is_joined' => function ($q) use ($user) {
+                    $q->where('users.id', $user->id);
                 },
             ]);
         if ($filter === 'joined') {
-            $query->whereHas('users', $activeMember);
+            $query->whereHas('activeUsersQuery', function ($q) use ($user) {
+                $q->where('users.id', $user->id);
+            });
         }
 
         if ($filter === 'not_joined') {
-            $query->whereDoesntHave('users', $activeMember);
+            $query->whereDoesntHave('activeUsersQuery', function ($q) use ($user) {
+                $q->where('users.id', $user->id);
+            });
         }
 
         $groups = $query->get();

--- a/src/laravel-chat/app/Http/Controllers/GroupController.php
+++ b/src/laravel-chat/app/Http/Controllers/GroupController.php
@@ -20,32 +20,27 @@ class GroupController extends Controller
         $user = Auth::user();
         $filter = $request->query('filter');
 
-        $query = Group::query()->whereNull('archived_at')
-            ->withExists(['users as is_joined' => function ($q) use ($user) {
-                $q->where('users.id', $user->id)
-                    ->whereNull('left_at')
-                    ->whereNotNull('joined_at');
-            },
+        $activeMember = function ($q) use ($user) {
+            $q->where('users.id', $user->id)
+                ->whereNull('left_at')
+                ->whereNotNull('joined_at');
+        };
 
-            'users as is_applying' => function ($q) use ($user) {
-                $q->where('users.id', $user->id)
+        $query = Group::query()
+            ->whereNull('archived_at')
+            ->withExists([
+                'users as is_joined' => $activeMember,
+                'users as is_applying' => function ($q) use ($user) {
+                    $q->where('users.id', $user->id)
                     ->where('role', 'applicant');
-            },]);
-
+                },
+            ]);
         if ($filter === 'joined') {
-            $query->whereHas('users', function ($q) use ($user) {
-                $q->where('users.id', $user->id)
-                    ->whereNull('left_at')
-                    ->whereNotNull('joined_at');
-            });
+            $query->whereHas('users', $activeMember);
         }
 
         if ($filter === 'not_joined') {
-            $query->whereDoesntHave('users', function ($q) use ($user) {
-                $q->where('users.id', $user->id)
-                    ->whereNull('left_at')
-                    ->whereNotNull('joined_at');
-            });
+            $query->whereDoesntHave('users', $activeMember);
         }
 
         $groups = $query->get();

--- a/src/laravel-chat/app/Http/Controllers/GroupController.php
+++ b/src/laravel-chat/app/Http/Controllers/GroupController.php
@@ -28,7 +28,8 @@ class GroupController extends Controller
                 },
 
                 'users as is_applying' => function ($q) use ($user) {
-                    $q->where('users.id', $user->id);
+                    $q->where('users.id', $user->id)
+                      ->where('role', 'applicant');
                 },
             ]);
         if ($filter === 'joined') {

--- a/src/laravel-chat/app/Http/Controllers/MemberController.php
+++ b/src/laravel-chat/app/Http/Controllers/MemberController.php
@@ -18,7 +18,7 @@ class MemberController extends Controller
         $group = Group::findOrFail($groupId);
         $user = Auth::user();
 
-        if ($group->activeUsers()->contains($user)) {
+        if ($group->isActiveMember($user)) {
             return redirect()->back()->with('info', 'すでにグループに参加しています');
         }
         $invitation = $group->invitations()
@@ -47,7 +47,7 @@ class MemberController extends Controller
     public function application(Group $group) {
         $user = Auth::user();
 
-        if ($group->activeUsers()->contains($user)) {
+        if ($group->isActiveMember($user) || $group->isApplicant($user)) {
             return redirect()->back()->with('info', '既にグループに参加しています');
         }
 

--- a/src/laravel-chat/app/Http/Controllers/MemberController.php
+++ b/src/laravel-chat/app/Http/Controllers/MemberController.php
@@ -18,7 +18,7 @@ class MemberController extends Controller
         $group = Group::findOrFail($groupId);
         $user = Auth::user();
 
-        if ($group->isJoinedBy($user)) {
+        if ($group->activeUsers()->contains($user)) {
             return redirect()->back()->with('info', 'すでにグループに参加しています');
         }
         $invitation = $group->invitations()
@@ -47,7 +47,7 @@ class MemberController extends Controller
     public function application(Group $group) {
         $user = Auth::user();
 
-        if ($group->isJoinedBy($user)) {
+        if ($group->activeUsers()->contains($user)) {
             return redirect()->back()->with('info', '既にグループに参加しています');
         }
 

--- a/src/laravel-chat/app/Http/Controllers/MessageController.php
+++ b/src/laravel-chat/app/Http/Controllers/MessageController.php
@@ -64,7 +64,7 @@ class MessageController extends Controller
 
         $beforeId = $validated['before_id'] ?? null;
 
-        if (!$group->activeUsers()->contains($user)) {
+        if (!$group->isActiveMember($user)) {
             abort(403, 'You are not a member of this group.');
         }
 

--- a/src/laravel-chat/app/Http/Controllers/MessageController.php
+++ b/src/laravel-chat/app/Http/Controllers/MessageController.php
@@ -34,7 +34,7 @@ class MessageController extends Controller
     public function store(Request $request, Group $group) {
         $user = Auth::user();
 
-        if (!$group->isJoinedBy($user)) {
+        if (!$group->activeUsers()->contains($user)) {
             return redirect()->route('groups.index')->with('error', 'このグループに参加していません');
         }
 
@@ -64,7 +64,7 @@ class MessageController extends Controller
 
         $beforeId = $validated['before_id'] ?? null;
 
-        if (!$group->isJoinedBy($user)) {
+        if (!$group->activeUsers()->contains($user)) {
             abort(403, 'You are not a member of this group.');
         }
 

--- a/src/laravel-chat/app/Http/Controllers/MessageController.php
+++ b/src/laravel-chat/app/Http/Controllers/MessageController.php
@@ -34,7 +34,7 @@ class MessageController extends Controller
     public function store(Request $request, Group $group) {
         $user = Auth::user();
 
-        if (!$group->activeUsers()->contains($user)) {
+        if (!$group->isActiveMember($user)) {
             return redirect()->route('groups.index')->with('error', 'このグループに参加していません');
         }
 

--- a/src/laravel-chat/app/Models/Group.php
+++ b/src/laravel-chat/app/Models/Group.php
@@ -14,12 +14,16 @@ class Group extends Model
         'description',
     ];
 
-    private function activeMemberQuery(User $user) {
+    private function activeUsersQuery(){
         return $this->users()
-        ->where('user_id', $user->id)
         ->wherePivot('role', '!=', 'applicant')
         ->wherePivotNull('left_at')
         ->wherePivotNotNull('joined_at');
+    }
+
+    private function activeMemberQuery(User $user) {
+        return $this->activeUsersQuery()
+        ->where('users.id', $user->id);
     }
 
     public function messages() {
@@ -37,13 +41,6 @@ class Group extends Model
         return $this->hasMany(Invitation::class);
     }
 
-    public function isJoinedBy(User $user)
-    {
-        return $this->activeMemberQuery($user)
-        ->wherePivotNotNull('joined_at')
-        ->exists();
-    }
-
     public function isActiveMember(User $user)
     {
         return $this->activeMemberQuery($user)->exists();
@@ -52,16 +49,11 @@ class Group extends Model
     public function isAdmin(User $user) {
         return $this->activeMemberQuery($user)
         ->wherePivot('role', 'admin')
-        ->wherePivotNotNull('joined_at')
         ->exists();
     }
 
     public function activeUsers() {
-        return $this->users()
-        ->wherePivot('left_at', null)
-        ->wherePivot('joined_at', '!=', null)
-        ->wherePivot('role', '!=', 'applicant')
-        ->get();
+        return $this->activeUsersQuery()->get();
     }
 
     public function removableUsers($activeUsers) {

--- a/src/laravel-chat/app/Models/Group.php
+++ b/src/laravel-chat/app/Models/Group.php
@@ -14,7 +14,7 @@ class Group extends Model
         'description',
     ];
 
-    private function activeUsersQuery(){
+    public function activeUsersQuery(){
         return $this->users()
         ->wherePivot('role', '!=', 'applicant')
         ->wherePivotNull('left_at')

--- a/src/laravel-chat/app/Policies/GroupPolicy.php
+++ b/src/laravel-chat/app/Policies/GroupPolicy.php
@@ -21,7 +21,7 @@ class GroupPolicy
      */
     public function view(User $user, Group $group): bool
     {
-        return $group->isJoinedBy($user);
+        return $group->activeUsers()->contains($user);
     }
 
     public function admin(User $user, Group $group): bool

--- a/src/laravel-chat/app/Policies/GroupPolicy.php
+++ b/src/laravel-chat/app/Policies/GroupPolicy.php
@@ -21,7 +21,7 @@ class GroupPolicy
      */
     public function view(User $user, Group $group): bool
     {
-        return $group->activeUsers()->contains($user);
+        return $group->isActiveMember($user);
     }
 
     public function admin(User $user, Group $group): bool

--- a/src/laravel-chat/app/Services/GroupAdminService.php
+++ b/src/laravel-chat/app/Services/GroupAdminService.php
@@ -24,11 +24,8 @@ class GroupAdminService
 
     public function adminCount(Group $group): int
     {
-        return $group->users()
+        return $group->activeUsersQuery()
             ->wherePivot('role', 'admin')
-            ->wherePivotNull('left_at')
-            ->wherePivotNotNull('joined_at')
-            ->lockForUpdate()
             ->count();
     }
 }

--- a/src/laravel-chat/app/Services/GroupAdminService.php
+++ b/src/laravel-chat/app/Services/GroupAdminService.php
@@ -26,6 +26,7 @@ class GroupAdminService
     {
         return $group->activeUsersQuery()
             ->wherePivot('role', 'admin')
+            ->lockForUpdate()
             ->count();
     }
 }

--- a/src/laravel-chat/tests/Feature/ApplicationTest.php
+++ b/src/laravel-chat/tests/Feature/ApplicationTest.php
@@ -189,6 +189,17 @@ class ApplicationTest extends TestCase
         $response->assertDontSeeText('参加申請');
     }
 
+    public function test_leftuser_displaying_application_to_join(): void
+    {
+        $this->actingAs($this->user);
+        $this->leftadminGroup($this->user, $this->group);
+
+        $response = $this->get(route('groups.index'));
+
+        $response->assertSeeText('参加申請');
+        $response->assertDontSeeText('申請中');
+    }
+
     public function test_applicant_can_cancel_application(): void
     {
         $this->actingAs($this->user);


### PR DESCRIPTION
- Group モデル内に、参加中ユーザーを表す共通処理 activeUsersQuery() を定義

-isActiveMember() と isAdmin() は、その共通処理を再利用する

- isJoinedBy() を削除

- activeUsers() の戻り値や呼び出し側に影響が出ないように整理

- GroupController@index  の重複条件も共通化

close #93 